### PR TITLE
Deserialize responses

### DIFF
--- a/Runtime/SimpleGraphQL/GraphQLClient.cs
+++ b/Runtime/SimpleGraphQL/GraphQLClient.cs
@@ -103,6 +103,17 @@ namespace SimpleGraphQL
             return JsonConvert.DeserializeObject<Response<TResponse>>(json);
         }
 
+        public async Task<Response<TResponse>> Send<TResponse>(
+            Func<TResponse> responseTypeResolver,
+            Query query,
+            Dictionary<string, object> variables = null,
+            Dictionary<string, string> headers = null,
+            string authToken = null,
+            string authScheme = null)
+        {
+            return await Send<TResponse>(query, variables, headers, authToken, authScheme);
+        }
+
         /// <summary>
         /// Send a query!
         /// </summary>

--- a/Runtime/SimpleGraphQL/GraphQLClient.cs
+++ b/Runtime/SimpleGraphQL/GraphQLClient.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Newtonsoft.Json;
 using UnityEngine;
 
 namespace SimpleGraphQL
@@ -88,6 +89,18 @@ namespace SimpleGraphQL
             );
 
             return postQueryAsync;
+        }
+
+        public async Task<Response<TResponse>> Send<TResponse>(
+            Query query,
+            Dictionary<string, object> variables = null,
+            Dictionary<string, string> headers = null,
+            string authToken = null,
+            string authScheme = null
+            )
+        {
+            var json = await Send(query, variables, headers, authToken, authScheme);
+            return JsonConvert.DeserializeObject<Response<TResponse>>(json);
         }
 
         /// <summary>

--- a/Runtime/SimpleGraphQL/Query.cs
+++ b/Runtime/SimpleGraphQL/Query.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 using System.Text;
 using JetBrains.Annotations;
 using Newtonsoft.Json;
@@ -39,6 +40,13 @@ namespace SimpleGraphQL
         {
             return $"{FileName}:{OperationName}:{OperationType}";
         }
+    }
+
+    [PublicAPI]
+    public class Response<T>
+    {
+        [DataMember(Name = "data")]
+        public Dictionary<string, T> Data { get; set; }
     }
 
     [PublicAPI]

--- a/Runtime/SimpleGraphQL/Query.cs
+++ b/Runtime/SimpleGraphQL/Query.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Runtime.Serialization;
 using System.Text;
 using JetBrains.Annotations;
 using Newtonsoft.Json;
@@ -40,13 +39,6 @@ namespace SimpleGraphQL
         {
             return $"{FileName}:{OperationName}:{OperationType}";
         }
-    }
-
-    [PublicAPI]
-    public class Response<T>
-    {
-        [DataMember(Name = "data")]
-        public T Data { get; set; }
     }
 
     [PublicAPI]

--- a/Runtime/SimpleGraphQL/Query.cs
+++ b/Runtime/SimpleGraphQL/Query.cs
@@ -46,7 +46,7 @@ namespace SimpleGraphQL
     public class Response<T>
     {
         [DataMember(Name = "data")]
-        public Dictionary<string, T> Data { get; set; }
+        public T Data { get; set; }
     }
 
     [PublicAPI]

--- a/Runtime/SimpleGraphQL/Response.cs
+++ b/Runtime/SimpleGraphQL/Response.cs
@@ -1,0 +1,12 @@
+﻿using System.Runtime.Serialization;
+using JetBrains.Annotations;
+
+namespace SimpleGraphQL
+{
+    [PublicAPI]
+    public class Response<T>
+    {
+        [DataMember(Name = "data")]
+        public T Data { get; set; }
+    }
+}

--- a/Runtime/SimpleGraphQL/Response.cs
+++ b/Runtime/SimpleGraphQL/Response.cs
@@ -8,5 +8,34 @@ namespace SimpleGraphQL
     {
         [DataMember(Name = "data")]
         public T Data { get; set; }
+
+        [DataMember(Name = "errors")]
+        [CanBeNull]
+        public Error[] Errors { get; set; }
+    }
+
+    [PublicAPI]
+    public class Error
+    {
+        [DataMember(Name = "message")]
+        public string Message { get; set; }
+
+        [DataMember(Name = "locations")]
+        [CanBeNull]
+        public Location[] Locations { get; set; }
+
+        [DataMember(Name = "path")]
+        [CanBeNull]
+        public object[] Path { get; set; } // Path objects can be either integers or strings
+    }
+
+    [PublicAPI]
+    public class Location
+    {
+        [DataMember(Name = "line")]
+        public int Line { get; set; }
+
+        [DataMember(Name = "column")]
+        public int Column { get; set; }
     }
 }

--- a/Runtime/SimpleGraphQL/Response.cs.meta
+++ b/Runtime/SimpleGraphQL/Response.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e37fe1a274a541f889a676866851a8c2
+timeCreated: 1620144704


### PR DESCRIPTION
This adds API similarly to https://github.com/graphql-dotnet/graphql-client

Like mentioned in one of the commit messages, this allows:

```c#
var query = new Query { Source = " { topLevelScores (level: \"Level1\") { score } } " };
var responseType = () => new { topLevelScores = new [] { new { score = 0} } };
var response = await client.Send(responseType, query);
Debug.Log(response.Data.topLevelScores[0].score);
```

But this could just as well be done in external code... not sure just how simple you want to keep the api?
