### PR TITLE
Make use of variables more ergonomic

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,10 +104,7 @@ public async void QueryOrMutation()
 
     string results = await graphQL.SendAsync(
         query,
-        new Dictionary<string, object>
-        {
-            {"variable", "value"}
-        },
+        new {variable = "value"},
         null,
        "authToken",
        "Bearer"
@@ -131,10 +128,7 @@ public async void Subscribe()
 
     bool success = await graphQL.SubscribeAsync(
         query,
-        new Dictionary<string, object>
-        {
-            {"variable", "value"}
-        },
+        new {variable = "value"},
         null,
        "authToken",
        "Bearer"
@@ -183,10 +177,7 @@ public IEnumerator _CallQueryCoroutine()
     yield return new WaitForSend(
         graphQL.SendAsync(
             query,
-            new Dictionary<string, object>
-            {
-                {"variable", "value"}
-            },
+            new {variable = "value"},
         ), 
         OnComplete
     );

--- a/Runtime/SimpleGraphQL/GraphQLClient.cs
+++ b/Runtime/SimpleGraphQL/GraphQLClient.cs
@@ -52,7 +52,7 @@ namespace SimpleGraphQL
         /// <returns></returns>
         public async Task<string> Send(
             Query query,
-            Dictionary<string, object> variables = null,
+            object variables = null,
             Dictionary<string, string> headers = null,
             string authToken = null,
             string authScheme = null
@@ -93,7 +93,7 @@ namespace SimpleGraphQL
 
         public async Task<Response<TResponse>> Send<TResponse>(
             Query query,
-            Dictionary<string, object> variables = null,
+            object variables = null,
             Dictionary<string, string> headers = null,
             string authToken = null,
             string authScheme = null
@@ -106,7 +106,7 @@ namespace SimpleGraphQL
         public async Task<Response<TResponse>> Send<TResponse>(
             Func<TResponse> responseTypeResolver,
             Query query,
-            Dictionary<string, object> variables = null,
+            object variables = null,
             Dictionary<string, string> headers = null,
             string authToken = null,
             string authScheme = null)
@@ -126,7 +126,7 @@ namespace SimpleGraphQL
         [Obsolete("SendAsync is deprecated, please use Send instead.")]
         public async Task<string> SendAsync(
             Query query,
-            Dictionary<string, object> variables = null,
+            object variables = null,
             Dictionary<string, string> headers = null,
             string authToken = null,
             string authScheme = null
@@ -164,7 +164,7 @@ namespace SimpleGraphQL
         /// <returns>True if successful</returns>
         public async Task<bool> Subscribe(
             Query query,
-            Dictionary<string, object> variables = null,
+            object variables = null,
             Dictionary<string, string> headers = null,
             string authToken = null,
             string authScheme = null
@@ -262,7 +262,7 @@ namespace SimpleGraphQL
         [Obsolete("SubscribeAsync is deprecated, please use Subscribe instead.")]
         public async Task<bool> SubscribeAsync(
             Query query,
-            Dictionary<string, object> variables = null,
+            object variables = null,
             Dictionary<string, string> headers = null,
             string authToken = null,
             string authScheme = null

--- a/Runtime/SimpleGraphQL/HttpUtils.cs
+++ b/Runtime/SimpleGraphQL/HttpUtils.cs
@@ -42,7 +42,7 @@ namespace SimpleGraphQL
         public static async Task<string> PostQueryAsync(
             string url,
             Query query,
-            Dictionary<string, object> variables = null,
+            object variables = null,
             Dictionary<string, string> headers = null,
             string authToken = null,
             string authScheme = null
@@ -177,7 +177,7 @@ namespace SimpleGraphQL
         public static async Task<bool> WebSocketSubscribe(
             string id,
             Query query,
-            Dictionary<string, object> variables
+            object variables
         )
         {
             if (!IsWebSocketReady())

--- a/Runtime/SimpleGraphQL/Query.cs
+++ b/Runtime/SimpleGraphQL/Query.cs
@@ -44,12 +44,12 @@ namespace SimpleGraphQL
     [PublicAPI]
     public static class QueryExtensions
     {
-        public static byte[] ToBytes(this Query query, Dictionary<string, object> variables = null)
+        public static byte[] ToBytes(this Query query, object variables = null)
         {
             return Encoding.UTF8.GetBytes(ToJson(query, variables));
         }
 
-        public static string ToJson(this Query query, Dictionary<string, object> variables = null,
+        public static string ToJson(this Query query, object variables = null,
             bool prettyPrint = false)
         {
             return JsonConvert.SerializeObject

--- a/Tests/Runtime/QueryTests.cs
+++ b/Tests/Runtime/QueryTests.cs
@@ -46,7 +46,7 @@ namespace SimpleGraphQL.Tests
         }
 
         [UnityTest]
-        public IEnumerator QueryWithArgs()
+        public IEnumerator QueryWithArgsDictionary()
         {
             var client = new GraphQLClient(Uri);
             var query = new Query
@@ -61,6 +61,31 @@ namespace SimpleGraphQL.Tests
                 {
                     {"code", "EU"}
                 }
+            );
+
+            yield return response.AsCoroutine();
+
+            Assert.IsNull(response.Result.Errors);
+
+            var data = response.Result.Data;
+            Assert.IsNotNull(data);
+            Assert.IsNotNull(data.continent);
+            Assert.AreEqual(data.continent.name, "Europe");
+        }
+
+        [UnityTest]
+        public IEnumerator QueryWithArgsObject()
+        {
+            var client = new GraphQLClient(Uri);
+            var query = new Query
+            {
+                Source = "query ContinentNameByCode($code: ID!) { continent(code: $code) { name } }"
+            };
+            var responseType = new { continent = new { name = "" } };
+            var response = client.Send(
+                () => responseType,
+                query,
+                new {code = "EU"}
             );
 
             yield return response.AsCoroutine();


### PR DESCRIPTION
Using `object` instead of a `Dictionary`

Similarly to how it's done in graphql-dotnet and the other unity
project.

I think this will break binary compatibility, but sending requests
should be source compatible (see tests).