### PR TITLE
Fix il2cpp stripping issues

### DIFF
--- a/Editor/LinkXmlInjector.cs
+++ b/Editor/LinkXmlInjector.cs
@@ -1,0 +1,32 @@
+﻿using System.IO;
+using UnityEditor;
+using UnityEditor.Build;
+using UnityEditor.Build.Reporting;
+using UnityEditor.UnityLinker;
+
+namespace SimpleGraphQL
+{
+    internal class LinkXmlInjector : IUnityLinkerProcessor
+    {
+        int IOrderedCallback.callbackOrder => 0;
+
+        string IUnityLinkerProcessor.GenerateAdditionalLinkXmlFile(BuildReport report, UnityLinkerBuildPipelineData data)
+        {
+            // This is pretty ugly, but it was the only thing I could think of in order to reliably get the path to link.xml
+            const string linkXmlGuid = "9bbe747a148f00540828ab8521feb770";
+            var assetPath = AssetDatabase.GUIDToAssetPath(linkXmlGuid);
+            // assets paths are relative to the unity project root, but they don't correspond to actual folders for
+            // Packages that are embedded. I.e. it won't work if a package is installed as a git submodule
+            // So resolve it to an absolute path:
+            return Path.GetFullPath(assetPath);
+        }
+
+        void IUnityLinkerProcessor.OnBeforeRun(BuildReport report, UnityLinkerBuildPipelineData data)
+        {
+        }
+
+        void IUnityLinkerProcessor.OnAfterRun(BuildReport report, UnityLinkerBuildPipelineData data)
+        {
+        }
+    }
+}

--- a/Editor/LinkXmlInjector.cs.meta
+++ b/Editor/LinkXmlInjector.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c8fd0dba505247129d30f405770dcd49
+timeCreated: 1623269528

--- a/Runtime/SimpleGraphQL/GraphQLClient.cs
+++ b/Runtime/SimpleGraphQL/GraphQLClient.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Utilities;
 using UnityEngine;
 
 namespace SimpleGraphQL
@@ -51,19 +52,12 @@ namespace SimpleGraphQL
         /// <param name="authScheme">The authScheme to be used.</param>
         /// <returns></returns>
         public async Task<string> Send(
-            Query query,
-            Dictionary<string, object> variables = null,
+            Request request,
             Dictionary<string, string> headers = null,
             string authToken = null,
             string authScheme = null
         )
         {
-            if (query.OperationType == OperationType.Subscription)
-            {
-                Debug.LogError("Operation Type should not be a subscription!");
-                return null;
-            }
-
             if (CustomHeaders != null)
             {
                 if (headers == null) headers = new Dictionary<string, string>();
@@ -79,10 +73,9 @@ namespace SimpleGraphQL
                 authScheme = AuthScheme;
             }
 
-            string postQueryAsync = await HttpUtils.PostQueryAsync(
+            string postQueryAsync = await HttpUtils.PostRequestAsync(
                 Endpoint,
-                query,
-                variables,
+                request,
                 headers,
                 authToken,
                 authScheme
@@ -92,26 +85,24 @@ namespace SimpleGraphQL
         }
 
         public async Task<Response<TResponse>> Send<TResponse>(
-            Query query,
-            Dictionary<string, object> variables = null,
+            Request request,
             Dictionary<string, string> headers = null,
             string authToken = null,
             string authScheme = null
             )
         {
-            var json = await Send(query, variables, headers, authToken, authScheme);
+            var json = await Send(request, headers, authToken, authScheme);
             return JsonConvert.DeserializeObject<Response<TResponse>>(json);
         }
 
         public async Task<Response<TResponse>> Send<TResponse>(
             Func<TResponse> responseTypeResolver,
-            Query query,
-            Dictionary<string, object> variables = null,
+            Request request,
             Dictionary<string, string> headers = null,
             string authToken = null,
             string authScheme = null)
         {
-            return await Send<TResponse>(query, variables, headers, authToken, authScheme);
+            return await Send<TResponse>(request, headers, authToken, authScheme);
         }
 
         /// <summary>
@@ -125,14 +116,13 @@ namespace SimpleGraphQL
         /// <returns></returns>
         [Obsolete("SendAsync is deprecated, please use Send instead.")]
         public async Task<string> SendAsync(
-            Query query,
-            Dictionary<string, object> variables = null,
+            Request request,
             Dictionary<string, string> headers = null,
             string authToken = null,
             string authScheme = null
         )
         {
-            return await Send(query, variables, headers, authToken, authScheme);
+            return await Send(request, headers, authToken, authScheme);
         }
 
         /// <summary>

--- a/Runtime/SimpleGraphQL/HttpUtils.cs
+++ b/Runtime/SimpleGraphQL/HttpUtils.cs
@@ -33,16 +33,14 @@ namespace SimpleGraphQL
         /// POST a query to the given endpoint url.
         /// </summary>
         /// <param name="url">The endpoint url.</param>
-        /// <param name="query">The query</param>
+        /// <param name="request">The GraphQL request</param>
         /// <param name="authScheme">The authentication scheme to be used.</param>
         /// <param name="authToken">The actual auth token.</param>
-        /// <param name="variables">Any variables you want to pass in</param>
         /// <param name="headers">Any headers that should be passed in</param>
         /// <returns></returns>
-        public static async Task<string> PostQueryAsync(
+        public static async Task<string> PostRequestAsync(
             string url,
-            Query query,
-            Dictionary<string, object> variables = null,
+            Request request,
             Dictionary<string, string> headers = null,
             string authToken = null,
             string authScheme = null
@@ -50,37 +48,37 @@ namespace SimpleGraphQL
         {
             var uri = new Uri(url);
 
-            byte[] payload = query.ToBytes(variables);
+            byte[] payload = request.ToBytes();
 
-            var request = new UnityWebRequest(uri, "POST")
+            var webRequest = new UnityWebRequest(uri, "POST")
             {
                 uploadHandler = new UploadHandlerRaw(payload),
                 downloadHandler = new DownloadHandlerBuffer()
             };
 
             if (authToken != null)
-                request.SetRequestHeader("Authorization", $"{authScheme} {authToken}");
+                webRequest.SetRequestHeader("Authorization", $"{authScheme} {authToken}");
 
-            request.SetRequestHeader("Content-Type", "application/json");
+            webRequest.SetRequestHeader("Content-Type", "application/json");
 
             if (headers != null)
             {
                 foreach (KeyValuePair<string, string> header in headers)
                 {
-                    request.SetRequestHeader(header.Key, header.Value);
+                    webRequest.SetRequestHeader(header.Key, header.Value);
                 }
             }
 
             try
             {
-                request.SendWebRequest();
+                webRequest.SendWebRequest();
 
-                while (!request.isDone)
+                while (!webRequest.isDone)
                 {
                     await Task.Yield();
                 }
 
-                return request.downloadHandler.text;
+                return webRequest.downloadHandler.text;
             }
             catch (Exception e)
             {

--- a/Runtime/SimpleGraphQL/Query.cs
+++ b/Runtime/SimpleGraphQL/Query.cs
@@ -1,8 +1,5 @@
 using System;
-using System.Collections.Generic;
-using System.Text;
 using JetBrains.Annotations;
-using Newtonsoft.Json;
 
 namespace SimpleGraphQL
 {
@@ -44,22 +41,14 @@ namespace SimpleGraphQL
     [PublicAPI]
     public static class QueryExtensions
     {
-        public static byte[] ToBytes(this Query query, Dictionary<string, object> variables = null)
+        public static Request ToRequest(this Query query, object variables = null)
         {
-            return Encoding.UTF8.GetBytes(ToJson(query, variables));
-        }
-
-        public static string ToJson(this Query query, Dictionary<string, object> variables = null,
-            bool prettyPrint = false)
-        {
-            return JsonConvert.SerializeObject
-            (new
-                {
-                    query = query.Source, operationName = query.OperationName, variables
-                },
-                prettyPrint ? Formatting.Indented : Formatting.None,
-                new JsonSerializerSettings {NullValueHandling = NullValueHandling.Ignore}
-            );
+            return new Request()
+            {
+                Query = query.Source,
+                Variables = variables,
+                OperationName = query.OperationName,
+            };
         }
     }
 

--- a/Runtime/SimpleGraphQL/Request.cs
+++ b/Runtime/SimpleGraphQL/Request.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Text;
+using JetBrains.Annotations;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace SimpleGraphQL
+{
+    [Serializable]
+    [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
+    public class Request
+    {
+        public string Query { get; set; }
+
+        [CanBeNull]
+        public string OperationName { get; set; }
+
+        public object Variables { get; set; }
+
+        public override string ToString()
+        {
+            return $"GraphQL Request:\n{this.ToJson(true)}";
+        }
+    }
+
+    [PublicAPI]
+    public static class RequestExtensions
+    {
+        public static byte[] ToBytes(this Request request)
+        {
+            return Encoding.UTF8.GetBytes(request.ToJson());
+        }
+
+        public static string ToJson(this Request request,
+            bool prettyPrint = false)
+        {
+            return JsonConvert.SerializeObject
+            (   request,
+                prettyPrint ? Formatting.Indented : Formatting.None,
+                new JsonSerializerSettings {NullValueHandling = NullValueHandling.Ignore}
+            );
+        }
+    }
+}

--- a/Runtime/SimpleGraphQL/Request.cs.meta
+++ b/Runtime/SimpleGraphQL/Request.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e14e44c4ba10492ab46ce11e7db590ba
+timeCreated: 1623267576

--- a/Tests/Runtime/QueryTests.cs
+++ b/Tests/Runtime/QueryTests.cs
@@ -15,9 +15,9 @@ namespace SimpleGraphQL.Tests
         public IEnumerator SimpleQuery()
         {
             var client = new GraphQLClient(Uri);
-            var query = new Query { Source = "{ continents { name } }" };
+            var request = new Request { Query = "{ continents { name } }" };
             var responseType = new { continents = new [] { new { name = "" } } };
-            var response = client.Send(() => responseType, query);
+            var response = client.Send(() => responseType, request);
 
             yield return response.AsCoroutine();
 
@@ -33,7 +33,7 @@ namespace SimpleGraphQL.Tests
         public IEnumerator FailedQuery()
         {
             var client = new GraphQLClient(Uri);
-            var query = new Query { Source = "{ continents MALFORMED name } }" };
+            var query = new Request { Query = "{ continents MALFORMED name } }" };
             var responseType = new { continents = new [] { new { name = "" } } };
             var response = client.Send(() => responseType, query);
 
@@ -49,19 +49,16 @@ namespace SimpleGraphQL.Tests
         public IEnumerator QueryWithArgs()
         {
             var client = new GraphQLClient(Uri);
-            var query = new Query
+            var request = new Request
             {
-                Source = "query ContinentNameByCode($code: ID!) { continent(code: $code) { name } }"
+                Query = "query ContinentNameByCode($code: ID!) { continent(code: $code) { name } }",
+                Variables = new
+                {
+                    code = "EU"
+                }
             };
             var responseType = new { continent = new { name = "" } };
-            var response = client.Send(
-                () => responseType,
-                query,
-                new Dictionary<string, object>()
-                {
-                    {"code", "EU"}
-                }
-            );
+            var response = client.Send(() => responseType, request);
 
             yield return response.AsCoroutine();
 

--- a/link.xml
+++ b/link.xml
@@ -1,0 +1,6 @@
+<linker>
+    <assembly fullname="LastAbyss.SimpleGraphQL.Runtime">
+        <type fullname="SimpleGraphQL.Response*" />
+        <type fullname="SimpleGraphQL.Request*" />
+    </assembly>
+</linker>

--- a/link.xml.meta
+++ b/link.xml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9bbe747a148f00540828ab8521feb770
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This PR does two things:

1. It injects a link.xml in order to tell unitylinker not to strip a couple of types
2. It refactors the API quite heavily in order to get rid of all usages of anonymous types

2 was done both in order to be able to make as narrow as possible entries for link.xml and because it makes the code-only api (without graphql source files) less awkward to use.

Fixes #15 