### PR TITLE
feat!: Throw exceptions when HTTP requests fail

### DIFF
--- a/Runtime/SimpleGraphQL/HttpUtils.cs
+++ b/Runtime/SimpleGraphQL/HttpUtils.cs
@@ -77,14 +77,19 @@ namespace SimpleGraphQL
                 {
                     await Task.Yield();
                 }
-
-                return webRequest.downloadHandler.text;
             }
             catch (Exception e)
             {
                 Debug.LogError("[SimpleGraphQL] " + e);
-                return null;
+                throw new UnityWebRequestException(webRequest);
             }
+
+            if (webRequest.result != UnityWebRequest.Result.Success)
+            {
+                throw new UnityWebRequestException(webRequest);
+            }
+
+            return webRequest.downloadHandler.text;
         }
 
         public static bool IsWebSocketReady() =>

--- a/Runtime/SimpleGraphQL/UnityWebRequestException.cs
+++ b/Runtime/SimpleGraphQL/UnityWebRequestException.cs
@@ -1,0 +1,89 @@
+﻿// Based on: https://github.com/Cysharp/UniTask/blob/master/src/UniTask/Assets/Plugins/UniTask/Runtime/UnityWebRequestException.cs
+
+// The MIT License (MIT)
+//
+// Copyright (c) 2019 Yoshifumi Kawai / Cysharp, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using UnityEngine.Networking;
+
+namespace SimpleGraphQL
+{
+    [PublicAPI]
+    public class UnityWebRequestException : Exception
+    {
+        public UnityWebRequest UnityWebRequest { get; }
+#if UNITY_2020_2_OR_NEWER
+        public UnityWebRequest.Result Result { get; }
+#else
+        public bool IsNetworkError { get; }
+        public bool IsHttpError { get; }
+#endif
+        public string Error { get; }
+        public string Text { get; }
+        public long ResponseCode { get; }
+        public Dictionary<string, string> ResponseHeaders { get; }
+
+        string msg;
+
+        public UnityWebRequestException(UnityWebRequest unityWebRequest)
+        {
+            this.UnityWebRequest = unityWebRequest;
+#if UNITY_2020_2_OR_NEWER
+            this.Result = unityWebRequest.result;
+#else
+            this.IsNetworkError = unityWebRequest.isNetworkError;
+            this.IsHttpError = unityWebRequest.isHttpError;
+#endif
+            this.Error = unityWebRequest.error;
+            this.ResponseCode = unityWebRequest.responseCode;
+            if (UnityWebRequest.downloadHandler != null)
+            {
+                if (unityWebRequest.downloadHandler is DownloadHandlerBuffer dhb)
+                {
+                    this.Text = dhb.text;
+                }
+            }
+            this.ResponseHeaders = unityWebRequest.GetResponseHeaders();
+        }
+
+        public override string Message
+        {
+            get
+            {
+                if (msg == null)
+                {
+                    if (Text != null)
+                    {
+                        msg = Error + Environment.NewLine + Text;
+                    }
+                    else
+                    {
+                        msg = Error;
+                    }
+                }
+                return msg;
+            }
+        }
+    }
+}

--- a/Runtime/SimpleGraphQL/UnityWebRequestException.cs.meta
+++ b/Runtime/SimpleGraphQL/UnityWebRequestException.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: aae9a1fa3eed469c8e7329b47b94a0b0
+timeCreated: 1624357139

--- a/Tests/Runtime/LastAbyss.SimpleGraphQL.Runtime.Tests.asmdef
+++ b/Tests/Runtime/LastAbyss.SimpleGraphQL.Runtime.Tests.asmdef
@@ -11,7 +11,8 @@
     "allowUnsafeCode": false,
     "overrideReferences": true,
     "precompiledReferences": [
-        "nunit.framework.dll"
+        "nunit.framework.dll",
+        "Newtonsoft.Json.dll"
     ],
     "autoReferenced": false,
     "defineConstraints": [

--- a/Tests/Runtime/QueryTests.cs
+++ b/Tests/Runtime/QueryTests.cs
@@ -1,8 +1,10 @@
+using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
+using UnityEngine.Networking;
 using UnityEngine.TestTools;
+using Newtonsoft.Json;
 
 namespace SimpleGraphQL.Tests
 {
@@ -30,19 +32,29 @@ namespace SimpleGraphQL.Tests
         }
 
         [UnityTest]
-        public IEnumerator FailedQuery()
+        public IEnumerator MalformedQuery()
         {
             var client = new GraphQLClient(Uri);
             var query = new Request { Query = "{ continents MALFORMED name } }" };
             var responseType = new { continents = new [] { new { name = "" } } };
             var response = client.Send(() => responseType, query);
 
-            yield return response.AsCoroutine();
+            yield return response.AsCoroutineUnchecked();
+            var ex = response.Expect<UnityWebRequestException>();
 
-            var errors = response.Result.Errors;
+            Assert.AreEqual(ex.ResponseCode, 400); // Bad request
+
+            var errors = DeserializeResponse(() => responseType, ex.Text).Errors;
+
             Assert.IsNotNull(errors);
             Assert.IsNotEmpty(errors);
             Assert.IsNotNull(errors[0].Message);
+        }
+
+        // Could be part of the library?
+        private Response<T> DeserializeResponse<T>(Func<T> responseTypeResolver, string json)
+        {
+            return JsonConvert.DeserializeObject<Response<T>>(json);
         }
 
         [UnityTest]
@@ -68,6 +80,41 @@ namespace SimpleGraphQL.Tests
             Assert.IsNotNull(data);
             Assert.IsNotNull(data.continent);
             Assert.AreEqual(data.continent.name, "Europe");
+        }
+
+        [UnityTest]
+        public IEnumerator NetworkError()
+        {
+            var client = new GraphQLClient("https://non_resolvable_host_123123123123123");
+            var request = new Request { Query = "{ continents { name } }" };
+            var responseType = new { continents = new [] { new { name = "" } } };
+            var response = client.Send(() => responseType, request);
+
+            yield return response.AsCoroutineUnchecked();
+            var ex = response.Expect<UnityWebRequestException>();
+#if UNITY_2020_2_OR_NEWER
+            Assert.AreEqual(ex.Result, UnityWebRequest.Result.ConnectionError);
+#else
+            Assert.IsTrue(ex.IsNetworkError);
+#endif
+        }
+
+        [UnityTest]
+        public IEnumerator Http404Error()
+        {
+            var client = new GraphQLClient("https://google.com/url_that_returns_404_lsdfksadjflksdafjs");
+            var request = new Request { Query = "{ continents { name } }" };
+            var responseType = new { continents = new [] { new { name = "" } } };
+            var response = client.Send(() => responseType, request);
+
+            yield return response.AsCoroutineUnchecked();
+            var ex = response.Expect<UnityWebRequestException>();
+#if UNITY_2020_2_OR_NEWER
+            Assert.AreEqual(ex.Result, UnityWebRequest.Result.ProtocolError);
+#else
+            Assert.IsTrue(ex.IsHttpError);
+#endif
+            Assert.AreEqual(ex.ResponseCode, 404);
         }
     }
 }

--- a/Tests/Runtime/UnityTestAsyncExtensions.cs
+++ b/Tests/Runtime/UnityTestAsyncExtensions.cs
@@ -1,5 +1,8 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Threading.Tasks;
+using NUnit.Framework;
+using UnityEngine;
 
 namespace SimpleGraphQL.Tests
 {
@@ -10,6 +13,33 @@ namespace SimpleGraphQL.Tests
             while (!task.IsCompleted) yield return null;
             // Throws if the Task fails
             task.GetAwaiter().GetResult();
+        }
+
+        // Doesn't check for errors
+        public static IEnumerator AsCoroutineUnchecked(this Task task)
+        {
+            while (!task.IsCompleted) yield return null;
+        }
+
+        public static void ThrowExceptions(this Task task)
+        {
+            Debug.Assert(task.IsCompleted);
+            task.GetAwaiter().GetResult();
+        }
+
+        public static T Expect<T>(this Task task)
+            where T: Exception
+        {
+            try
+            {
+                task.ThrowExceptions();
+            }
+            catch (T ex)
+            {
+                Assert.IsNotNull(ex);
+                return ex; // OK!
+            }
+            throw new AssertionException($"Expected task to throw {typeof(T)}");
         }
     }
 }


### PR DESCRIPTION
Needed in order to handle different kind of failures appropriately. For
instance when implementing a login flow.

BREAKING CHANGE: This means that some queries that previously returned a
`Response<T>` object with errors in it now throw
`UnityWebRequestException` instead.

I copied the `UnityWebRequestException` class from Cysharp.UniTask.

See the tests for how this affects existing error handling.

Fixes #18 