### PR TITLE
fix: Stripping issues after switching to Unity's Newtonsoft.Json

### DIFF
--- a/link.xml
+++ b/link.xml
@@ -2,5 +2,18 @@
     <assembly fullname="LastAbyss.SimpleGraphQL.Runtime">
         <type fullname="SimpleGraphQL.Response*" />
         <type fullname="SimpleGraphQL.Request*" />
+
+    </assembly>
+    <assembly fullname="Newtonsoft.Json">
+        <!-- https://github.com/jilleJr/Newtonsoft.Json-for-Unity/issues/54 -->
+        <type fullname="System.Runtime.CompilerServices.NullableAttribute"/>
+        <type fullname="System.Runtime.CompilerServices.NullableContextAttribute"/>
+
+        <!-- https://github.com/jilleJr/Newtonsoft.Json-for-Unity/issues/8 -->
+        <!-- https://github.com/jilleJr/Newtonsoft.Json-for-Unity/issues/65 -->
+        <type fullname="Newtonsoft.Json.Converters.*Converter" preserve="all" />
+
+        <!-- Not strictly needed, but these are quite commonly used in response types -->
+        <type fullname="Newtonsoft.Json.Serialization.*NamingStrategy" preserve="all" />
     </assembly>
 </linker>


### PR DESCRIPTION
jilleJr/Newtonsoft.Json-for-Unity added these automatically, but the
Unity package manager version doesn't.

They're not always needed, but just makes the library a lot easier to
use if you use naming strategy attributes on the deserializable objects,
i.e.:

```c#
[JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy))]
private class InsertResponse
{
    public int? AffectedRows { get; set; }
}

// ...

var result = await apiClient.Send(() => new { result = new InsertResponse() }, request);

```

Now works correctly.