### PR TITLE
Subscription listeners per subscription + support for graphql-transport-ws subprotocol

### DIFF
--- a/Runtime/SimpleGraphQL/GraphQLClient.cs
+++ b/Runtime/SimpleGraphQL/GraphQLClient.cs
@@ -112,6 +112,19 @@ namespace SimpleGraphQL
             HttpUtils.SubscriptionDataReceived += listener;
         }
 
+        public void RegisterListener(string id, Action<string> listener)
+        {
+            if(!HttpUtils.SubscriptionDataReceivedPerChannel.ContainsKey(id)) {
+              HttpUtils.SubscriptionDataReceivedPerChannel[id] = null;
+            }
+            HttpUtils.SubscriptionDataReceivedPerChannel[id] += listener;
+        }
+
+        public void RegisterListener(Request request, Action<string> listener)
+        {
+            RegisterListener(request.Query.ToMurmur2Hash().ToString(), listener);
+        }
+
         /// <summary>
         /// Unregisters a listener for subscriptions.
         /// </summary>
@@ -119,6 +132,18 @@ namespace SimpleGraphQL
         public void UnregisterListener(Action<string> listener)
         {
             HttpUtils.SubscriptionDataReceived -= listener;
+        }
+
+        public void UnregisterListener(string id, Action<string> listener)
+        {
+            if(HttpUtils.SubscriptionDataReceivedPerChannel.ContainsKey(id)) {
+              HttpUtils.SubscriptionDataReceivedPerChannel[id] -= listener;
+            }
+        }
+
+        public void UnregisterListener(Request request, Action<string> listener)
+        {
+            UnregisterListener(request.Query.ToMurmur2Hash().ToString(), listener);
         }
 
         /// <summary>

--- a/Runtime/SimpleGraphQL/HttpUtils.cs
+++ b/Runtime/SimpleGraphQL/HttpUtils.cs
@@ -140,18 +140,23 @@ namespace SimpleGraphQL
             _webSocket = new ClientWebSocket();
             _webSocket.Options.AddSubProtocol(protocol);
 
-            var payload = protocol == 'graphql-transport-ws' ? new {Authorization = null, "content-type", "application/json"} : new {};
+            var payload = new Dictionary<string, string>();
+
+            if(protocol == "graphql-transport-ws") {
+              payload["content-type"] = "application/json";
+            } else {
+              _webSocket.Options.SetRequestHeader("Content-Type", "application/json");
+            }
 
             if (authToken != null) {
-                if(protocol == 'graphql-transport-ws') {
+                if(protocol == "graphql-transport-ws") {
                     // set Authorization as payload
-                    payload.Authorization = $"{authScheme} {authToken}";
+                    payload["Authorization"] = $"{authScheme} {authToken}";
                 } else {
                     _webSocket.Options.SetRequestHeader("Authorization", $"{authScheme} {authToken}");
                 }
             }
 
-            _webSocket.Options.SetRequestHeader("Content-Type", "application/json");
 
             if (headers != null)
             {
@@ -335,7 +340,7 @@ namespace SimpleGraphQL
                         if (jToken != null)
                         {
                             SubscriptionDataReceived?.Invoke(jToken.ToString());
-                            SubscriptionDataReceived?[id]?.Invoke(jToken.ToString());
+                            SubscriptionDataReceivedPerChannel?[id]?.Invoke(jToken.ToString());
                         }
 
                         continue;


### PR DESCRIPTION
PR fixes 2 issues:

1. Separate your listeners per subscription, so you can know what data to expect from an update.

```
private Action<Challenge> subscriptionListener;
...
public void HandlePayload(string payload) {
    Debug.Log("Challenges subscription updated: " + payload);
    var responseType = new { Data = new { myActiveChallenges = new Challenge() }};
    subscriptionListener(JsonConvert.DeserializeAnonymousType(payload, responseType).Data.myActiveChallenges);
  }
```

2. Support for graphql-transport-ws where:
- authorization + other headers are set on init payload
- subscribe/complete commands VS start/stop commands