### PR TITLE
Added JsonSerializerSettings pass through

### DIFF
--- a/Runtime/SimpleGraphQL/GraphQLClient.cs
+++ b/Runtime/SimpleGraphQL/GraphQLClient.cs
@@ -51,6 +51,7 @@ namespace SimpleGraphQL
         /// <returns></returns>
         public async Task<string> Send(
             Request request,
+            JsonSerializerSettings serializerSettings = null,
             Dictionary<string, string> headers = null,
             string authToken = null,
             string authScheme = null
@@ -74,6 +75,7 @@ namespace SimpleGraphQL
             string postQueryAsync = await HttpUtils.PostRequest(
                 Endpoint,
                 request,
+                serializerSettings,
                 headers,
                 authToken,
                 authScheme
@@ -84,23 +86,25 @@ namespace SimpleGraphQL
 
         public async Task<Response<TResponse>> Send<TResponse>(
             Request request,
+            JsonSerializerSettings serializerSettings = null,
             Dictionary<string, string> headers = null,
             string authToken = null,
             string authScheme = null
         )
         {
-            string json = await Send(request, headers, authToken, authScheme);
+            string json = await Send(request, serializerSettings, headers, authToken, authScheme);
             return JsonConvert.DeserializeObject<Response<TResponse>>(json);
         }
 
         public async Task<Response<TResponse>> Send<TResponse>(
             Func<TResponse> responseTypeResolver,
             Request request,
+            JsonSerializerSettings serializerSettings = null,
             Dictionary<string, string> headers = null,
             string authToken = null,
             string authScheme = null)
         {
-            return await Send<TResponse>(request, headers, authToken, authScheme);
+            return await Send<TResponse>(request, serializerSettings, headers, authToken, authScheme);
         }
 
         /// <summary>

--- a/Runtime/SimpleGraphQL/HttpUtils.cs
+++ b/Runtime/SimpleGraphQL/HttpUtils.cs
@@ -52,6 +52,7 @@ namespace SimpleGraphQL
         public static async Task<string> PostRequest(
             string url,
             Request request,
+            JsonSerializerSettings serializerSettings = null,
             Dictionary<string, string> headers = null,
             string authToken = null,
             string authScheme = null
@@ -59,7 +60,7 @@ namespace SimpleGraphQL
         {
             var uri = new Uri(url);
 
-            byte[] payload = request.ToBytes();
+            byte[] payload = request.ToBytes(serializerSettings);
 
             using (var webRequest = new UnityWebRequest(uri, "POST")
             {

--- a/Runtime/SimpleGraphQL/Request.cs
+++ b/Runtime/SimpleGraphQL/Request.cs
@@ -26,18 +26,23 @@ namespace SimpleGraphQL
     [PublicAPI]
     public static class RequestExtensions
     {
-        public static byte[] ToBytes(this Request request)
+        private static JsonSerializerSettings defaultSerializerSettings = new JsonSerializerSettings {NullValueHandling = NullValueHandling.Ignore};
+        public static byte[] ToBytes(this Request request, JsonSerializerSettings serializerSettings = null)
         {
-            return Encoding.UTF8.GetBytes(request.ToJson());
+            return Encoding.UTF8.GetBytes(request.ToJson(false, serializerSettings));
         }
 
-        public static string ToJson(this Request request,
-            bool prettyPrint = false)
+        public static string ToJson(this Request request, bool prettyPrint = false, JsonSerializerSettings serializerSettings = null)
         {
+            if (serializerSettings == null)
+            {
+                serializerSettings = defaultSerializerSettings;
+            }
+            
             return JsonConvert.SerializeObject
             (   request,
                 prettyPrint ? Formatting.Indented : Formatting.None,
-                new JsonSerializerSettings {NullValueHandling = NullValueHandling.Ignore}
+                serializerSettings
             );
         }
     }


### PR DESCRIPTION
I am having a problem serializing Vector2/Vector3 because of an endless loop with Vector2 containing another Vector2 and so on. This can be fixed by setting `ReferenceLoopHandling = ReferenceLoopHandling.Ignore` as a JsonSerializerSetting. My first thought was to just add that option to [RequestExtensions](https://github.com/statespacelabs/SimpleGraphQL-For-Unity/blob/b4a473becf9d0558d1b103dddc1826c23a81f582/Runtime/SimpleGraphQL/Request.cs#L27), but then I figured there might be other options down the line that we want to use and it would probably be better to pass through the entire JsonSerializerSetting object.

So this PR still allows passthrough of the object and also protects the default settings to still be backwards compatible.

One problem it introduces is that all code calling this that already has used headers, authtoken or authscheme needs to be fixed, but its trivial so I dont think it'll matter that much.